### PR TITLE
Update injector for re-mounted components

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -23,13 +23,14 @@ function getRenderer(): Renderer {
     },
     mount(element, key, component, injector, props) {
       // LIMITATION: If an element is remounted with the same identifier, the component cannot be replaced
-      const exists = customElements.get(key)
-
-      if (!exists) {
-        customElements.define(key, createCustomElement(component, { injector }))
+      let CustomElement = customElements.get(key)
+      
+      if (!CustomElement) {
+        CustomElement = createCustomElement(component, { injector })
+        customElements.define(key, CustomElement)
       }
 
-      const ngElement = document.createElement(key) as NodeProps & NgElement & typeof props
+      const ngElement = new CustomElement(injector) as NodeProps & NgElement & typeof props
 
       Object.keys(props).forEach(key => {
         ngElement[key] = props[key]


### PR DESCRIPTION
### Description

Hi all, this is my first contribution here, please let me know if I missed something obvious. I wanted to open an issue but since the fix was quite straightforward I jumped ahead and opened this PR. 

I noticed that with the current implementation if you override the default IDs created by rete with your own the renderer would not correctly update the injector context for custom elements. As stated [here](https://github.com/retejs/angular-plugin/blob/main/src/core.ts#L25), the limitation was quite known already. 

This PR partially addresses the limitation but at least allows the next-created elements to correctly get a new injector with the correct instances. 

### Related Issues

None.

### Checklist

<!-- Mark the items that apply to this pull request -->

- [X] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

I'm wondering if it is really correct to have as the identifier of the CustomElement the identifier of the node. Wouldn't be better to use the component class name? or something that does not change for each data payload contained in the node? In my understanding, in the current solution if your retejs instance contains N nodes then we are defining N different CustomElement even if we would probably need way lass (one of each CustomElement type defined by the developer).  
